### PR TITLE
Update ServoPresets.cs

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Servo/ServoPresets.cs
+++ b/InfernalRobotics/InfernalRobotics/Servo/ServoPresets.cs
@@ -88,12 +88,12 @@ namespace InfernalRobotics_v3.Servo
 			if(Servo.PresetPositions == null || Servo.PresetPositions.Count == 0)
 				return;
 
-			ceiling = Servo.PresetPositions.FindIndex(p => p > Servo.Position + 0.005f);
+			ceiling = Servo.PresetPositions.FindIndex(p => p > Servo.Position + 0.015f);
 
 			if(ceiling == -1)
 				ceiling = Servo.PresetPositions.Count - 1;
 
-			floor = Servo.PresetPositions.FindLastIndex(p => p < Servo.Position - 0.005f);
+			floor = Servo.PresetPositions.FindLastIndex(p => p < Servo.Position - 0.015f);
 
 			if(floor == -1)
 				floor = 0;


### PR DESCRIPTION
Servo movement as a 0.01 programmed error. this causes to detect false presets when this error takes place. most of the times when this error happens, it's permanent/static and repetitive request will not cause anything to move.  
the 0.005 is considered for calculation error. summed with 0.01 will solve this issue.
i have reviewed the movement requests when the issue happens with adding debug.log to the code and certain spots and the logs kept saying requests are made a position while the servo stands at a distance 0.01 of this position. i looked the code up and saw that this error is programmed at the end of Interpolator.PrepareUpdate.