### PR TITLE
Stop servo group memberships accumulating on vessel activation

### DIFF
--- a/InfernalRobotics/InfernalRobotics/Command/Controller.cs
+++ b/InfernalRobotics/InfernalRobotics/Command/Controller.cs
@@ -209,9 +209,17 @@ namespace InfernalRobotics_v3.Command
 					{
 						List<string> groups = new List<string>(s.groupName.Split('|'));
 
+						// A servo belongs to a group at most once; skip any repeated
+						// membership so a groupName that was persisted with duplicate tokens
+						// does not add the servo to the same group more than once.
+						var seenGroups = new HashSet<string>();
+
 						foreach(string group in groups)
 						{
 							string[] gi = group.Split(';');
+
+							if(!seenGroups.Add(gi[0]))
+								continue;
 
 							List<ServoWithIndex> servos;
 							if(!groupServos.TryGetValue(gi[0], out servos))
@@ -310,9 +318,17 @@ namespace InfernalRobotics_v3.Command
 				{
 					List<string> groups = new List<string>(s.groupName.Split('|'));
 
+					// A servo belongs to a group at most once; skip any repeated membership
+					// so a groupName that was persisted with duplicate tokens does not add
+					// the servo to the same group more than once.
+					var seenGroups = new HashSet<string>();
+
 					foreach(string group in groups)
 					{
 						string[] gi = group.Split(';');
+
+						if(!seenGroups.Add(gi[0]))
+							continue;
 
 						List<ServoWithIndex> servos;
 						if(!groupServos.TryGetValue(gi[0], out servos))

--- a/InfernalRobotics/InfernalRobotics/Module/ModuleIRServo_v3.cs
+++ b/InfernalRobotics/InfernalRobotics/Module/ModuleIRServo_v3.cs
@@ -2385,7 +2385,22 @@ if(ip.isModulo) // deckt schon alles ab von wegen keine limits und kein minmax u
 			GroupPosition m = new GroupPosition();
 			m.group = group; m.index = index;
 
-			GroupPositions.Add(m);
+			// A servo belongs to a group at most once, and a group is identified by its
+			// name (rebuilding the servo groups creates fresh group objects for the same
+			// names). If this servo already has a membership for the group, replace it in
+			// place so repeated rebuilds refresh the entry instead of accumulating stale
+			// duplicates that would grow groupName without bound.
+			int existing = -1;
+			for(int i = 0; i < GroupPositions.Count; i++)
+			{
+				if(GroupPositions[i].group.Name == group.Name)
+				{ existing = i; break; }
+			}
+
+			if(existing >= 0)
+				GroupPositions[existing] = m;
+			else
+				GroupPositions.Add(m);
 
 			for(int i = 0; i < part.symmetryCounterparts.Count; i++)
 				part.symmetryCounterparts[i].GetComponent<ModuleIRServo_v3>().GroupPositions = new List<GroupPosition>(GroupPositions);


### PR DESCRIPTION
Switching to and from a vessel that carries a grouped set of servos makes each servo report as a member of its group multiple times, and the servo's persistent `groupName` field grows longer on every vessel activation.

This was discovered by using the kRPC mod to interact with Infernal Robotics: https://github.com/krpc/krpc/pull/1014

**Root cause.** A servo's group memberships are held in the runtime `GroupPositions` list, which `SerializeGroupNames` writes back into the persistent `groupName` field. Rebuilding the servo groups — for example on each vessel activation in flight via `RebuildServoGroupsFlight` — creates fresh `ServoGroup` objects and calls `ServoGroup.Refresh`, which removes and then re-adds each servo's membership. `RemoveGroup` matched the group by object reference, so it never found the entry left by a previous rebuild (that entry pointed at a now-discarded `ServoGroup`), and `AddGroup` simply appended a new one. `GroupPositions` therefore grew by a duplicate membership on each activation, `groupName` accumulated repeated `<group>;<index>` tokens without bound, and anything parsing `groupName` saw the servo several times in the group.

**Fix.** `AddGroup` now identifies a group by its name and replaces an existing membership in place instead of appending, so repeated rebuilds refresh the entry rather than piling up stale duplicates, and the stored entry always references the live group object. When rebuilding groups from `groupName`, a membership already seen for that servo is skipped, so a `groupName` that was already persisted with duplicate tokens does not add a servo to the same group more than once (and self-heals on the next serialization).

**Testing.** Verified in KSP 1.12.5 by repeatedly switching to and away from a vessel carrying a grouped servo set: the reported group membership stays stable across switches and `groupName` no longer grows, where previously each activation added another copy.
